### PR TITLE
Add quarter as a budget interval.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ Budget your time with `org-mode`!
 You can specify the intervals you want to use by customizing
 `org-clock-budget-intervals`.
 
-Currently three intervals are built-in, week, month and year.  To add
-a budget on a task, just add a property (`C-c C-x p`) called either
-`BUDGET_WEEK`, `BUDGET_MONTH` or `BUDGET_YEAR`.
+Currently four intervals are built-in, week, month, quarter (3-month period)
+and year. To add a budget on a task, just add a property (`C-c C-x p`)
+called either `BUDGET_WEEK`, `BUDGET_MONTH`, `BUDGET_QUARTER`, or
+`BUDGET_YEAR`.
 
 In addition, users can also define their own intervals.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ and you wish to work on it for 3 weeks.  Therefore, you'd budget 10
 hours weekly to work on this task and no more, allocating the rest of
 the time to other tasks.  If your estimate was too little, you will
 simply extend the period for another week of 10 hours.  If it was too
-little, you can re-budget the surplus time on other tasks.
+much, you can re-budget the surplus time on other tasks.
 
 ## Why should I want to budget my time?
 

--- a/org-clock-budget.el
+++ b/org-clock-budget.el
@@ -43,6 +43,7 @@
 (defcustom org-clock-budget-intervals
   '(
     ("BUDGET_YEAR" org-clock-budget-interval-this-year)
+    ("BUDGET_QUARTER" org-clock-budget-interval-this-quarter)
     ("BUDGET_MONTH" org-clock-budget-interval-this-month)
     ("BUDGET_WEEK" org-clock-budget-interval-this-week)
     )

--- a/org-clock-budget.el
+++ b/org-clock-budget.el
@@ -113,6 +113,22 @@ face."
                          (string-to-number (format-time-string "%m"))
                          (string-to-number (format-time-string "%Y")))))))
 
+(defun org-clock-budget-interval-this-quarter ()
+  "Return the interval representing this quarter (3-month period)."
+  (let* ((current-quarter
+          ;; [0, 3]
+          (/ (- (string-to-number (format-time-string "%m")) 1) 3))
+         (first-month (+ (* 3 current-quarter) 1))
+         (last-month (+ first-month 2)))
+    (cons
+     (format-time-string (format "%%Y-%2d-01" first-month))
+     (format-time-string (format
+                          "%%Y-%2d-%2d 23:59:59"
+                          last-month
+                          (calendar-last-day-of-month
+                           last-month
+                           (string-to-number (format-time-string "%Y"))))))))
+
 (defun org-clock-budget-interval-this-year ()
   "Return the interval representing this year."
   (cons


### PR DESCRIPTION
Adds quarter (a 3-month period) as an optional budget interval. I think people will find this useful when trying to find a planning middle ground between year and month.

If accepted, I can update the README to mention that this is available.